### PR TITLE
chore: pin dependency versions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { parse } from "https://deno.land/std/flags/mod.ts"
+import { parse } from "https://deno.land/std@0.74.0/flags/mod.ts"
 import { normalize } from "https://deno.land/std@0.70.0/path/mod.ts"
 
 // ----- cli ----- //

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { parse } from "https://cdn.skypack.dev/html5parser";
-import { Application, Context, send } from "https://deno.land/x/oak/mod.ts";
+import { Application, Context, send } from "https://deno.land/x/oak@v6.3.1/mod.ts";
 
-import type { WebSocket } from "https://deno.land/std/ws/mod.ts";
+import type { WebSocket } from "https://deno.land/std@0.74.0/ws/mod.ts";
 import {
   copySync,
   emptyDirSync,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import tosource from "https://cdn.skypack.dev/tosource"
 import type { IAttribute } from "https://cdn.skypack.dev/html5parser"
-import { parse } from "https://deno.land/std/flags/mod.ts"
+import { parse } from "https://deno.land/std@0.74.0/flags/mod.ts"
 import {
   red,
   blue,

--- a/ssgo.ts
+++ b/ssgo.ts
@@ -1,5 +1,5 @@
-import { parse } from "https://deno.land/std/flags/mod.ts"
-import type { WebSocket } from "https://deno.land/std/ws/mod.ts"
+import { parse } from "https://deno.land/std@0.74.0/flags/mod.ts"
+import type { WebSocket } from "https://deno.land/std@0.74.0/ws/mod.ts"
 import { build, watch, serve, init, sitemap, upgrade } from "./src/index.ts"
 import {
   DEV_FLAG,


### PR DESCRIPTION
This is a temporary fix for issues experienced in: https://github.com/mdubourg001/ssgo/issues/8

It would be nice if a policy of pinning versions could be adopted going forward though.