### PR TITLE
fix(build): prevent array mutation in for-of rendering

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -105,7 +105,7 @@ function computeForOf(
     const parent = "body" in node.parent ? node.parent.body : node.parent;
 
     let index = evaluatedOf.length - 1;
-    for (const item of evaluatedOf.reverse()) {
+    for (const item of [...evaluatedOf].reverse()) {
       const clone: INode = cloneDeep(node);
       clone.parent = node.parent;
       pushBefore(parent as INode[], node, clone);

--- a/src/test/forof.test.ts
+++ b/src/test/forof.test.ts
@@ -45,4 +45,12 @@ Deno.test("for/of attribute should be properly computed", async () => {
     ),
     "<div><p>0 - foo - false</p><p>1 - bar - true</p></div>"
   )
+
+  // values are not mutated
+  const items = ["foo", "bar"]
+  await buildHtmlAndSerialize(
+    `<p for="item" of="items">{{ item }}</p>`,
+    { items }
+  )
+  assertEquals(items, ["foo", "bar"])
 })


### PR DESCRIPTION
fixes #12 

Note: I restored the previous version of `src/test/helpers.ts` to run the test locally. ref: #11 